### PR TITLE
80% more efficient encoding for urls

### DIFF
--- a/public/js/comp.js
+++ b/public/js/comp.js
@@ -114,7 +114,6 @@ drum.service("Storage", function() {
     for(var i in track.channels) {
       var binaryChannel = '';
       for(var j = 0; j < 32; j++) {
-        console.log(i);
         binaryChannel += (track.channels[i].length > j ? track.channels[i][j] : '0');
       }
       radix36Track += parseInt(binaryChannel, 2).toString(36)+',';


### PR DESCRIPTION
I fixed the url encoding by converting individual channels to binary and encoding in base36. It's pretty efficient. It's probably backwards compatible with the old base64 urls and 80% shorter. I don't know why I bothered. Kappa

Comparison:
http://jytkytys.fi/#/eyJ0ZW1wbyI6MTM0LCJiZWF0Q291bnQiOjgsImNoYW5uZWxzIjp7InNuYXJlIjpbXSwiY2xhcCI6WzAsMCwxLDAsMCwwLDEsMSwwLDAsMSwwLDAsMCwxLDAsMCwwLDEsMCwwLDAsMSwwLDAsMCwxLDAsMCwwLDAsMF0sImtpY2siOlsxLDAsMCwwLDEsMCwwLDAsMSwwLDAsMCwxLDAsMCwwLDEsMCwwLDAsMSwwLDAsMCwxLDAsMCwxLDEsMSwxLDFdLCJoYXRDbG9zZWQiOltdLCJoYXRPcGVuIjpbXSwianl0a3lJbCI6WzEsMCwwLDAsMCwwLDAsMCwxXSwianl0SWwiOlswLDAsMCwwLDAsMCwwLDAsMCwwLDAsMCwwLDAsMCwwLDEsMCwwLDAsMV0sImt5SWwiOltdLCJqeXRreU1hcyI6W10sImp5dE1hcyI6W10sImt5TWFzIjpbXSwianl0a3l0ZXTk5G4iOlswLDAsMCwwLDAsMCwwLDAsMCwwLDAsMCwwLDAsMCwwLDAsMCwwLDAsMCwwLDAsMCwxXSwidPZt5Gh0aSI6W10sImthaGVuS2lsb24iOltdLCJzaWlrYSI6W119fQ%253D%253D
becomes
http://jytkytys.fi/#/0,9qxqg0,11vsk9r,0,0,znjtog,qv4,0,0,0,0,3k,0,0,0,3q

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apkoponen/jytkytin2015/1)
<!-- Reviewable:end -->
